### PR TITLE
Add card editing and camera capture improvements

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Needed for capturing images with the camera -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/cardify/cardbook/CardBookViewModel.kt
+++ b/app/src/main/java/com/example/cardify/cardbook/CardBookViewModel.kt
@@ -3,6 +3,7 @@ package com.example.cardify.cardbook
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
 import com.example.cardify.models.BusinessCard
+import com.example.cardify.models.CardIdManager
 
 /** Simple in-memory storage for business cards. */
 class CardBookViewModel : ViewModel() {
@@ -10,7 +11,12 @@ class CardBookViewModel : ViewModel() {
     val cards: List<BusinessCard> = _cards
 
     fun addCard(card: BusinessCard) {
-        _cards.add(card)
+        val cardWithId = if (card.cardId.isEmpty()) {
+            card.copy(cardId = CardIdManager.getNextId())
+        } else {
+            card
+        }
+        _cards.add(cardWithId)
     }
 
     fun updateCard(index: Int, card: BusinessCard) {

--- a/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
@@ -28,6 +28,7 @@ import com.example.cardify.models.LoginViewModel
 import com.example.cardify.models.MainScreenViewModel
 import com.example.cardify.cardbook.CardBookViewModel
 import com.example.cardify.ui.screens.CardBookScreen
+import com.example.cardify.ui.screens.CardDetailScreen
 import com.example.cardify.ui.screens.AddExistingScreen
 import com.example.cardify.ui.screens.EditCardScreen
 import com.example.cardify.ui.screens.OcrResultScreen
@@ -289,6 +290,14 @@ val token = tokenManager.getToken()
 
             composable(Screen.CardBook.route) {
                 CardBookScreen(navController = navController, viewModel = cardBookViewModel)
+            }
+
+            composable(
+                route = Screen.CardDetail.route,
+                arguments = listOf(navArgument("cardId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val cardId = backStackEntry.arguments?.getString("cardId") ?: ""
+                CardDetailScreen(navController = navController, cardId = cardId)
             }
 
             composable(

--- a/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
@@ -288,7 +288,7 @@ val token = tokenManager.getToken()
             }
 
             composable(Screen.CardBook.route) {
-                CardBookScreen(navController = navController)
+                CardBookScreen(navController = navController, viewModel = cardBookViewModel)
             }
 
             composable(

--- a/app/src/main/java/com/example/cardify/ui/screens/AddExistingScreen.kt
+++ b/app/src/main/java/com/example/cardify/ui/screens/AddExistingScreen.kt
@@ -1,7 +1,8 @@
 package com.example.cardify.ui.screens
 
 import android.Manifest
-import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.core.content.FileProvider
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -23,6 +24,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.core.content.ContextCompat
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,7 +35,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
-import android.net.Uri
+import java.io.File
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,22 +49,22 @@ fun AddExistingScreen(
         contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
         uri?.let {
-            val inputStream = context.contentResolver.openInputStream(it)
-            val bitmap = BitmapFactory.decodeStream(inputStream)
-            inputStream?.close()
-            if (bitmap != null) {
-                com.example.cardify.ocr.CapturedImageHolder.bitmap = bitmap
-                navController.navigate(com.example.cardify.navigation.Screen.OcrResult.route)
-            }
+            navController.navigate(
+                com.example.cardify.navigation.Screen.AddImageSelect.createRoute(it.toString())
+            )
         }
     }
-    
+
+    var photoUri by remember { mutableStateOf<Uri?>(null) }
     val cameraLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.TakePicturePreview()
-    ) { bitmap ->
-        bitmap?.let {
-            com.example.cardify.ocr.CapturedImageHolder.bitmap = it
-            navController.navigate(com.example.cardify.navigation.Screen.OcrResult.route)
+        contract = ActivityResultContracts.TakePicture()
+    ) { success ->
+        if (success) {
+            photoUri?.let { uri ->
+                navController.navigate(
+                    com.example.cardify.navigation.Screen.AddImageSelect.createRoute(uri.toString())
+                )
+            }
         }
     }
 
@@ -69,7 +72,7 @@ fun AddExistingScreen(
         contract = ActivityResultContracts.RequestPermission()
     ) { isGranted ->
         if (isGranted) {
-            cameraLauncher.launch(null)
+            photoUri?.let { cameraLauncher.launch(it) }
         }
     }
     
@@ -124,8 +127,10 @@ fun AddExistingScreen(
 
             Button(onClick = {
                 val permission = android.Manifest.permission.CAMERA
+                val file = File.createTempFile("camera_", ".jpg", context.cacheDir)
+                photoUri = FileProvider.getUriForFile(context, "${context.packageName}.provider", file)
                 if (ContextCompat.checkSelfPermission(context, permission) == android.content.pm.PackageManager.PERMISSION_GRANTED) {
-                    cameraLauncher.launch(null)
+                    photoUri?.let { cameraLauncher.launch(it) }
                 } else {
                     permissionLauncher.launch(permission)
                 }

--- a/app/src/main/java/com/example/cardify/ui/screens/AddExistingScreen.kt
+++ b/app/src/main/java/com/example/cardify/ui/screens/AddExistingScreen.kt
@@ -24,8 +24,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,7 +60,7 @@ fun AddExistingScreen(
     var photoUri by remember { mutableStateOf<Uri?>(null) }
     val cameraLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.TakePicture()
-    ) { success ->
+    ) { success: Boolean ->
         if (success) {
             photoUri?.let { uri ->
                 navController.navigate(

--- a/app/src/main/java/com/example/cardify/ui/screens/CardBookScreen.kt
+++ b/app/src/main/java/com/example/cardify/ui/screens/CardBookScreen.kt
@@ -1,16 +1,30 @@
 package com.example.cardify.ui.screens
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.example.cardify.cardbook.CardBookViewModel
+import com.example.cardify.navigation.Screen
+import com.example.cardify.ui.components.Base64Image
 import com.example.cardify.ui.components.BottomNavBar
 
 @Composable
-fun CardBookScreen(navController: NavController) {
+fun CardBookScreen(navController: NavController, viewModel: CardBookViewModel) {
     Scaffold(
         bottomBar = {
             BottomNavBar(
@@ -21,6 +35,44 @@ fun CardBookScreen(navController: NavController) {
             )
         }
     ) { padding ->
-        Box(modifier = Modifier.fillMaxSize().padding(padding))
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            itemsIndexed(viewModel.cards) { index, card ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (card.imageUrl.isNotEmpty()) {
+                        Base64Image(
+                            base64 = card.imageUrl,
+                            modifier = Modifier
+                                .size(48.dp)
+                                .clip(CircleShape)
+                        )
+                    }
+
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(start = 12.dp)
+                    ) {
+                        Text(text = card.name, color = Color.Black)
+                        Text(text = card.phone, color = Color.Gray)
+                        Text(text = card.email, color = Color.Gray)
+                    }
+
+                    IconButton(onClick = {
+                        navController.navigate(Screen.EditCard.createRoute(index))
+                    }) {
+                        Icon(Icons.Default.Edit, contentDescription = "Edit")
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/cardify/ui/screens/CardDetailScreen.kt
+++ b/app/src/main/java/com/example/cardify/ui/screens/CardDetailScreen.kt
@@ -1,0 +1,20 @@
+package com.example.cardify.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+
+@Composable
+fun CardDetailScreen(navController: NavController, cardId: String) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = "Card Detail for $cardId")
+    }
+}
+

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="images" path="." />
+    <external-files-path name="external_images" path="." />
+</paths>


### PR DESCRIPTION
## Summary
- allow capturing camera images with FileProvider and share them to the existing card registration flow
- show saved business cards in the Card Book tab with an edit button
- hook CardBookScreen to navigation and pass view model
- create FileProvider paths for camera capture

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843fe70f554832fbd947fbce7b810d1